### PR TITLE
Addresses #50 a fix for k8s 1.6

### DIFF
--- a/k8s/example2/configmap.yml
+++ b/k8s/example2/configmap.yml
@@ -4,6 +4,7 @@ metadata:
   name: application-config
 data:
   # DB service
+  app.db.database: "application"
   app.db.cluster.name: "application_cluster"
   app.db.cluster.replication.db: "replica_db"
   app.db.pool.backends: "0:application-db-node1-service::::,1:application-db-node2-service::::,2:application-db-node3-service::::"

--- a/k8s/example2/service1.yml
+++ b/k8s/example2/service1.yml
@@ -7,8 +7,10 @@ metadata:
     node: node1
     system: application
 spec:
+  clusterIP: None
   ports:
     - port: 5432
+      targetPort: 5432
   selector:
     name: database
     node: node1

--- a/k8s/example2/service2.yml
+++ b/k8s/example2/service2.yml
@@ -7,6 +7,7 @@ metadata:
     node: node2
     system: application
 spec:
+  clusterIP: None
   ports:
     - port: 5432
       targetPort: 5432

--- a/k8s/example2/service3.yml
+++ b/k8s/example2/service3.yml
@@ -7,6 +7,7 @@ metadata:
     node: node3
     system: application
 spec:
+  clusterIP: None
   ports:
     - port: 5432
       targetPort: 5432


### PR DESCRIPTION
To reproduce the problem I used minikube v0.19.0 (runs k8s 1.6)
and kubectl 1.6.3

Changing node services to headless by adding ``clusterIP: None``
made it possible to successfully run the ``k8s/example2``. I did not
have to do this change when I was using k8s 1.5.x

The PR also fixes a small bug with ``ConfigMap``