### PR TITLE
Small Documentation changes

### DIFF
--- a/FLOWS.md
+++ b/FLOWS.md
@@ -4,7 +4,7 @@ Using only `docker-compose` utility we can run some scenarios to demonstrate the
 
 ## Master crash
 
-* Start cluster `docker-compose up`
+* Start cluster `docker-compose up -d`
 * Kill master container and in a few moments cluster will define new master node `docker-compose stop pgmaster`
 * `pgpool` will try to detect new primary node for write access automatically.
 * See topology after master death
@@ -36,7 +36,7 @@ docker-compose exec pgpool bash -c 'PGPASSWORD=$CHECK_PASSWORD psql -U $CHECK_US
 
 The flow should proof that `pgpool` never has 2 primary nodes in the same moment.
 
-* Start pgpool with 2 write nodes `docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml up pgpool2` 
+* Start pgpool with 2 write nodes `docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml up -d pgpool2`
 * See how pgpool reacts on two nodes with write access 
 ```
 docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml exec pgpool2 bash -c 'PGPASSWORD=$CHECK_PASSWORD psql -U $CHECK_USER -h localhost template1 -c "show pool_nodes"'
@@ -124,7 +124,7 @@ docker-compose exec pgpool bash -c 'PGPASSWORD=$CHECK_PASSWORD psql -U $CHECK_US
  1       | pgslave1 | 5432 | 2      | 0.250000  | standby
  3       | pgslave3 | 5432 | 3      | 0.250000  | standby
 ```
-* Bringing back lost slave will add it to cluster (but not to `pgpool`) - `docker-compose up pgslave3`
+* Bringing back lost slave will add it to cluster (but not to `pgpool`) - `docker-compose up -d pgslave3`
 ```
 docker-compose exec pgmaster bash -c "gosu postgres repmgr cluster show"
 [2016-12-27 17:52:21] [INFO] connecting to database

--- a/FLOWS.md
+++ b/FLOWS.md
@@ -56,7 +56,7 @@ docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml ex
  1       | pgmaster2 | 5432 | 2      | 0.500000  | primary
 ```
 * Provide connection to node again `docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml exec pgpool2 bash -c "cat /etc/hosts | grep -v pgmaster > /etc/hosts.tmp && cat /etc/hosts.tmp > /etc/hosts"`
-* And attach node back to the pool `docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml exec pgpool2 bash -c "pcp_attach_node 10 localhost 9898 pcp_user pcp_pass 0"`
+* And attach node back to the pool `docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml exec pgpool2 bash -c 'pcp_attach_node -h localhost -U $PCP_USER -w 0'`
 * Check `pgpool`, it should have initial node back as a primary node
 ```
 docker-compose -f docker-compose.yml -f docker-compose/split-brain-pgpool.yml exec pgpool2 bash -c 'PGPASSWORD=$CHECK_PASSWORD psql -U $CHECK_USER -h localhost template1 -c "show pool_nodes"'
@@ -135,7 +135,7 @@ Role      | Name  | Upstream | Connection String
   standby | node4 | node1    | user=replication_user password=replication_pass host=pgslave3 dbname=replication_db port=5432 connect_timeout=2
 ```
 
-You can attach node to `pgpool` by command: `docker-compose exec pgpool bash -c 'pcp_attach_node 10 localhost 9898 $PCP_USER $PCP_PASSWORD 3'`
+You can attach node to `pgpool` by command: `docker-compose exec pgpool bash -c 'pcp_attach_node -h localhost -U $PCP_USER 3'`
 And check `pgpool`
 ```
 docker-compose exec pgpool bash -c 'PGPASSWORD=$CHECK_PASSWORD psql -U $CHECK_USER -h localhost template1 -c "show pool_nodes"'

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 ### What's in the box
 [This project](https://github.com/paunin/postgres-docker-cluster) includes:
 * dockerfiles for `postgresql` cluster
-    * [postgresql](./Pgsql.Dockerfile)
-    * [pgpool](./Pgpool.Dockerfile)
+    * [postgresql](./Postgres-latest.Dockerfile)
+    * [pgpool](./Pgpool-latest.Dockerfile)
 * Examples of usage(suitable for production environment as architecture has fault protection with auto failover)
     * example of [docker-compose](./docker-compose.yml) file to start this cluster.
     * directory [k8s](./k8s) contains information for building this cluster in kubernetes

--- a/docker-compose/split-brain-pgpool.yml
+++ b/docker-compose/split-brain-pgpool.yml
@@ -4,7 +4,7 @@ services:
 #        image: paunin/postgresql-cluster-pgsql
         build:
             context: .
-            dockerfile: Pgsql.Dockerfile
+            dockerfile: Postgres-latest.Dockerfile
         environment:
 
             NODE_ID: 1
@@ -26,7 +26,7 @@ services:
 #        image: paunin/postgresql-cluster-pgpool
         build:
             context: .
-            dockerfile: Pgpool.Dockerfile
+            dockerfile: Pgpool-latest.Dockerfile
         depends_on:
             - pgmaster
             - pgmaster2

--- a/pgpool/bin/entrypoint.sh
+++ b/pgpool/bin/entrypoint.sh
@@ -13,6 +13,10 @@ echo "host all all 0.0.0.0/0 md5" > $HBA_FILE
 echo ">>> Adding user $PCP_USER for PCP"
 echo "$PCP_USER:`pg_md5 --config-file $CONFIG_FILE $PCP_PASSWORD`" >> $PCP_FILE
 
+echo ">>> Creating a ~/.pcppass file for $PCP_USER"
+echo localhost:9898:$PCP_USER:$PCP_PASSWORD >~/.pcppass
+chmod 0600 ~/.pcppass
+
 echo ">>> Adding users for md5 auth"
 IFS=',' read -ra USER_PASSES <<< "$DB_USERS"
 for USER_PASS in ${USER_PASSES[@]}


### PR DESCRIPTION
As I was testing the examples I discovered a few small problems:

* typo when some old Dockerfile names remain referenced
* not using up -d was tying terminals
* the pcp_attach_node syntax is not valid
* pcp_attach_node calls can be simplified by creating a .pcppass
  file in the entrypoint